### PR TITLE
Make shops work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 ##
 ## Get latest from https://github.com/github/gitignore/blob/master/VisualStudio.gitignore
 
+# Local build properties
+LocalBuildProperties.props
+
 # User-specific files
 *.rsuser
 *.suo

--- a/RandoVanillaTracker/PlacementModifier.cs
+++ b/RandoVanillaTracker/PlacementModifier.cs
@@ -22,7 +22,6 @@ namespace RandoVanillaTracker
             RequestBuilder.OnUpdate.Subscribe(300f, TrackTransitions);
             RequestBuilder.OnUpdate.Subscribe(5000f, TrackInteropItems);
             RequestBuilder.OnUpdate.Subscribe(300f, DerandomizeTrackedItems);
-            RequestBuilder.OnUpdate.Subscribe(300f, RemoveShopCostRandomize);
         }
 
         private static void TrackTransitions(RequestBuilder rb)
@@ -66,23 +65,6 @@ namespace RandoVanillaTracker
             }
         }
 
-        // Stop the randomizer from adding randomized geo costs to shops
-        private static void RemoveShopCostRandomize(RequestBuilder rb)
-        {
-            string[] shops = new[]
-            {
-                LocationNames.Sly, LocationNames.Sly_Key, LocationNames.Iselda, LocationNames.Salubra, LocationNames.Leg_Eater,
-            };
-
-            foreach (string s in shops)
-            {
-                rb.EditLocationRequest(s, info =>
-                {
-                    info.onRandomizerFinish = null;
-                });
-            }
-        }
-
         private static HashSet<string> recordedPools = new();
 
         // Trick the randomizer into thinking that the pools are randomized
@@ -101,7 +83,7 @@ namespace RandoVanillaTracker
                 if (RVT.GS.GetFieldByName(pool.Path.Replace("PoolSettings.", "")) && pool.IsVanilla(rb.gs))
                 {
                     recordedPools.Add(pool.Name);
-                    Util.Set(rb.gs.PoolSettings, pool.Path, true);
+                    rb.gs.Set(pool.Path, true);
 
                     foreach (VanillaDef vd in pool.Vanilla)
                     {

--- a/RandoVanillaTracker/PlacementModifier.cs
+++ b/RandoVanillaTracker/PlacementModifier.cs
@@ -1,9 +1,11 @@
 ﻿using ItemChanger;
+using RandomizerMod.Logging;
 using RandomizerMod.RandomizerData;
 using RandomizerMod.RC;
 using RandomizerMod.Settings;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using ElementType = RandomizerMod.RC.RequestBuilder.ElementType;
 using RVT = RandoVanillaTracker.RandoVanillaTracker;
@@ -22,6 +24,19 @@ namespace RandoVanillaTracker
             RequestBuilder.OnUpdate.Subscribe(300f, TrackTransitions);
             RequestBuilder.OnUpdate.Subscribe(5000f, TrackInteropItems);
             RequestBuilder.OnUpdate.Subscribe(300f, DerandomizeTrackedItems);
+
+            SettingsLog.AfterLogSettings += LogRVTSettings;
+        }
+
+        private static HashSet<string> recordedPools = new();
+
+        private static void LogRVTSettings(LogArguments args, TextWriter tw)
+        {
+            tw.WriteLine("RandoVanillaTracker Tracked Pools");
+            foreach (string s in recordedPools)
+            {
+                tw.WriteLine($"- {s}");
+            }
         }
 
         private static void TrackTransitions(RequestBuilder rb)
@@ -64,8 +79,6 @@ namespace RandoVanillaTracker
                 }
             }
         }
-
-        private static HashSet<string> recordedPools = new();
 
         // Trick the randomizer into thinking that the pools are randomized
         private static void RecordTrackedPools(RequestBuilder rb)

--- a/RandoVanillaTracker/PlacementModifier.cs
+++ b/RandoVanillaTracker/PlacementModifier.cs
@@ -1,5 +1,4 @@
-﻿using ItemChanger;
-using RandomizerMod.Logging;
+﻿using RandomizerMod.Logging;
 using RandomizerMod.RandomizerData;
 using RandomizerMod.RC;
 using RandomizerMod.Settings;
@@ -45,7 +44,7 @@ namespace RandoVanillaTracker
 
             VanillaItemGroupBuilder vb = GetVanillaGroupBuilder(rb);
 
-            foreach (VanillaDef vd in rb.Vanilla.Values.SelectMany(x => x))
+            foreach (VanillaDef vd in rb.Vanilla.Values.SelectMany(x => x).ToList())
             {
                 if (Data.IsTransition(vd.Item) && Data.IsTransition(vd.Location))
                 {

--- a/RandoVanillaTracker/RandoVanillaTracker.csproj
+++ b/RandoVanillaTracker/RandoVanillaTracker.csproj
@@ -42,6 +42,9 @@
     <Reference Include="MenuChanger">
       <HintPath>$(HollowKnightRefs)\Mods\MenuChanger\MenuChanger.dll</HintPath>
     </Reference>
+    <Reference Include="ItemChanger">
+      <HintPath>$(HollowKnightRefs)\Mods\ItemChanger\ItemChanger.dll</HintPath>
+    </Reference>
     <Reference Include="MMHOOK_Assembly-CSharp">
       <HintPath>$(HollowKnightRefs)\MMHOOK_Assembly-CSharp.dll</HintPath>
     </Reference>

--- a/RandoVanillaTracker/RandoVanillaTracker.csproj
+++ b/RandoVanillaTracker/RandoVanillaTracker.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
+  <PropertyGroup>
     <TargetFramework>net472</TargetFramework>
     <AssemblyVersion>4.0.0</AssemblyVersion>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <LangVersion>latest</LangVersion>
     <Deterministic>true</Deterministic>
-	<HollowKnightRefs>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed</HollowKnightRefs>
+	  <HollowKnightRefs>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed</HollowKnightRefs>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -27,6 +27,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
 
+  <Import Project="LocalBuildProperties.props" Condition="Exists('LocalBuildProperties.props')" />
+  
   <ItemGroup>
     <Compile Remove="Unused\**" />
     <EmbeddedResource Remove="Unused\**" />
@@ -35,34 +37,34 @@
 
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="MenuChanger">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Mods\MenuChanger\MenuChanger.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\Mods\MenuChanger\MenuChanger.dll</HintPath>
     </Reference>
     <Reference Include="MMHOOK_Assembly-CSharp">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\MMHOOK_Assembly-CSharp.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\MMHOOK_Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="MonoMod.RuntimeDetour">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\MonoMod.RuntimeDetour.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\MonoMod.RuntimeDetour.dll</HintPath>
     </Reference>
     <Reference Include="MonoMod.Utils">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\MonoMod.Utils.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\MonoMod.Utils.dll</HintPath>
     </Reference>
     <Reference Include="RandomizerCore">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Mods\RandomizerCore\RandomizerCore.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\Mods\RandomizerCore\RandomizerCore.dll</HintPath>
     </Reference>
     <Reference Include="RandomizerMod">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\Mods\Randomizer 4\RandomizerMod.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\Mods\Randomizer 4\RandomizerMod.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>C:\Program Files (x86)\Steam\steamapps\common\Hollow Knight\hollow_knight_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>$(HollowKnightRefs)\UnityEngine.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
 

--- a/RandoVanillaTracker/VanillaItemGroupBuilder.cs
+++ b/RandoVanillaTracker/VanillaItemGroupBuilder.cs
@@ -10,12 +10,50 @@ namespace RandoVanillaTracker
 {
     public class VanillaItemGroupBuilder : GroupBuilder
     {
+        public static readonly Dictionary<string, int> UniqueShopCostLookup = new()
+        {
+            [ItemNames.Wayward_Compass] = 220,
+            
+            [ItemNames.Simple_Key] = 950,
+            [ItemNames.Rancid_Egg] = 50,
+            [ItemNames.Lumafly_Lantern] = 1800,
+            [ItemNames.Gathering_Swarm] = 300,
+            [ItemNames.Stalwart_Shell] = 300,
+            [ItemNames.Heavy_Blow] = 350,
+            [ItemNames.Elegant_Key] = 800,
+            [ItemNames.Sprintmaster] = 400,
+
+            [ItemNames.Longnail] = 300,
+            [ItemNames.Shaman_Stone] = 220,
+            [ItemNames.Lifeblood_Heart] = 250,
+            [ItemNames.Steady_Body] = 120,
+            [ItemNames.Quick_Focus] = 800,
+
+            [ItemNames.Fragile_Heart] = 350,
+            [ItemNames.Fragile_Greed] = 250,
+            [ItemNames.Fragile_Strength] = 600,
+        };
+
+        public static readonly HashSet<string> ShopNames = new()
+        {
+            LocationNames.Iselda,
+            LocationNames.Sly,
+            LocationNames.Sly_Key,
+            LocationNames.Salubra,
+            LocationNames.Leg_Eater,
+        };
+
+        public static readonly List<int> SlyMaskShardCosts = new() { 150, 500, 800, 1500 };
+        public static readonly List<int> SlyVesselFragmentCosts = new() { 550, 900 };
+
         public List<VanillaDef> VanillaPlacements = new();
         public List<VanillaDef> VanillaTransitions = new();
 
         public override void Apply(List<RandomizationGroup> groups, RandoFactory factory)
         {
             int count = 0;
+            int slyMaskShards = 0;
+            int slyVesselFragments = 0;
 
             foreach (VanillaDef vd in VanillaPlacements)
             {
@@ -26,7 +64,7 @@ namespace RandoVanillaTracker
                 if (vd.Costs is not null)
                 {
                     // Clear cost for grubfather/seer added by randomizer
-                    if ((vd.Location == LocationNames.Grubfather || vd.Location == LocationNames.Seer) && vd.Costs is not null)
+                    if ((vd.Location == LocationNames.Grubfather || vd.Location == LocationNames.Seer) && location.costs is not null)
                     {
                         location.costs.Clear();
                     }
@@ -42,6 +80,29 @@ namespace RandoVanillaTracker
                                 location.AddCost(new SimpleCost(factory.lm.GetTerm(cost.Term), cost.Amount));
                                 break;
                         }
+                    }
+                }
+
+                else if (ShopNames.Contains(vd.Location))
+                {
+                    if (location.costs is not null)
+                    {
+                        location.costs.Clear();
+                    }
+
+                    if (UniqueShopCostLookup.TryGetValue(vd.Item, out int amount))
+                    {
+                        location.AddCost(new LogicGeoCost(factory.lm, amount));
+                    }
+                    else if (vd.Item == ItemNames.Mask_Shard)
+                    {
+                        location.AddCost(new LogicGeoCost(factory.lm, SlyMaskShardCosts[slyMaskShards]));
+                        slyMaskShards++;
+                    }
+                    else if (vd.Item == ItemNames.Vessel_Fragment)
+                    {
+                        location.AddCost(new LogicGeoCost(factory.lm, SlyMaskShardCosts[slyVesselFragments]));
+                        slyVesselFragments++;
                     }
                 }
 

--- a/RandoVanillaTracker/VanillaItemGroupBuilder.cs
+++ b/RandoVanillaTracker/VanillaItemGroupBuilder.cs
@@ -1,0 +1,74 @@
+﻿using ItemChanger;
+using RandomizerCore.Logic;
+using RandomizerCore.Randomization;
+using RandomizerMod.RandomizerData;
+using RandomizerMod.RC;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RandoVanillaTracker
+{
+    public class VanillaItemGroupBuilder : GroupBuilder
+    {
+        public List<VanillaDef> VanillaPlacements = new();
+        public List<VanillaDef> VanillaTransitions = new();
+
+        public override void Apply(List<RandomizationGroup> groups, RandoFactory factory)
+        {
+            int count = 0;
+
+            foreach (VanillaDef vd in VanillaPlacements)
+            {
+                RandoModItem item = factory.MakeItem(vd.Item);
+                
+                RandoModLocation location = factory.MakeLocation(vd.Location);
+
+                if (vd.Costs is not null)
+                {
+                    // Clear cost for grubfather/seer added by randomizer
+                    if ((vd.Location == LocationNames.Grubfather || vd.Location == LocationNames.Seer) && vd.Costs is not null)
+                    {
+                        location.costs.Clear();
+                    }
+
+                    foreach (CostDef cost in vd.Costs ?? Enumerable.Empty<CostDef>())
+                    {
+                        switch (cost.Term)
+                        {
+                            case "GEO":
+                                location.AddCost(new LogicGeoCost(factory.lm, cost.Amount));
+                                break;
+                            default:
+                                location.AddCost(new SimpleCost(factory.lm.GetTerm(cost.Term), cost.Amount));
+                                break;
+                        }
+                    }
+                }
+
+                RandomizationGroup group = new()
+                {
+                    Items = new[] { item },
+                    Locations = new[] { location },
+                    Label = $"{label}-{++count}",
+                    Strategy = strategy ?? factory.gs.ProgressionDepthSettings.GetItemPlacementStrategy(),
+                };
+
+                groups.Add(group);
+            }
+
+            foreach (VanillaDef vd in VanillaTransitions)
+            {
+                RandomizationGroup group = new()
+                {
+                    Items = new[] { factory.MakeTransition(vd.Item) },
+                    Locations = new[] { factory.MakeTransition(vd.Location) },
+                    Label = $"{label}-{++count}",
+                    Strategy = strategy ?? factory.gs.ProgressionDepthSettings.GetTransitionPlacementStrategy(),
+                };
+
+                groups.Add(group);
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
Main issue is that it requires the user to set tolerances etc to ensure that vanilla tracked items are all reachable. That said if they do this then shop charms etc are now correctly tracked and priced.


Side issue - I don't know how this works with salubra notches, egg shop and untrackable items (such as split skills). It's generally not recommended to play with vanilla and split skills though so the last one might not be a problem.

(Swim and cursed nail aren't relevant because they have no vanilla location; EPass isn't really trackable because the rando EPass item doesn't correspond identically to the vanilla EPass item)